### PR TITLE
value.Len: fix comment about return value to 0 instead of "null value"

### DIFF
--- a/read.go
+++ b/read.go
@@ -696,7 +696,7 @@ func (v Value) Index(i int) Value {
 }
 
 // Len returns the length of the array v.
-// If v.Kind() != Array, Len returns a null Value.
+// If v.Kind() != Array, Len returns 0.
 func (v Value) Len() int {
 	x, ok := v.data.(array)
 	if !ok {


### PR DESCRIPTION
Fix up the doc on Len() to call out that
Len() returns 0 instead of "a null value".