### PR TITLE
Save startxref in Reader

### DIFF
--- a/read.go
+++ b/read.go
@@ -79,6 +79,7 @@ import (
 type Reader struct {
 	f          io.ReaderAt
 	end        int64
+	startxref  int64
 	xref       []xref
 	trailer    dict
 	trailerptr objptr
@@ -161,6 +162,7 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 	if err != nil {
 		return nil, err
 	}
+	r.startxref = startxref
 	r.xref = xref
 	r.trailer = trailer
 	r.trailerptr = trailerptr


### PR DESCRIPTION
The location of the last xref structure is needed when saving a new
PDF. It should be in the trailer dict as /Prev.

Here it is used when reading the PDF and thus available. It only needs to
be saved. Accessing it can done from another place, later.