### PR TITLE
Correct func name in TextHorizontal comment

### DIFF
--- a/page.go
+++ b/page.go
@@ -629,7 +629,7 @@ func (x TextVertical) Less(i, j int) bool {
 	return x[i].X < x[j].X
 }
 
-// TextVertical implements sort.Interface for sorting
+// TextHorizontal implements sort.Interface for sorting
 // a slice of Text values in horizontal order, left to right,
 // and then top to bottom within a column.
 type TextHorizontal []Text


### PR DESCRIPTION
What
===
Change the func name in the comment on `TextHorizontal` from
`TextVertical` to `TextHorizontal`.

Why
===
The first word in a func comment should be the name of the func, in this
case `TextHorizontal`.