### PR TITLE
Use keyed fields in struct literals to appease go vet on Google AppEngine

### DIFF
--- a/read.go
+++ b/read.go
@@ -1052,7 +1052,7 @@ func decryptStream(key []byte, useAES bool, ptr objptr, rd io.Reader) io.Reader 
 		rd = &cbcReader{cbc: cbc, rd: rd, buf: make([]byte, 16)}
 	} else {
 		c, _ := rc4.NewCipher(key)
-		rd = &cipher.StreamReader{c, rd}
+		rd = &cipher.StreamReader{S: c, R: rd}
 	}
 	return rd
 }


### PR DESCRIPTION
What
===
Use keyed fields in struct literals.

Why
===
When pushing code to Google AppEngine that uses rsc.io/pdf, the code is
rejected with the error:

rsc.io/pdf/read.go:1055:9: composite struct literal crypto/cipher.StreamReader with unkeyed fields

I don't see this error locally with go1.9, and assume this is a feature
of go vet that has improved since go1.8.