### PR TITLE
Add a Go import comment

### DIFF
--- a/pdfpasswd/main.go
+++ b/pdfpasswd/main.go
@@ -4,7 +4,7 @@
 
 // Pdfpasswd searches for the password for an encrypted PDF
 // by trying all strings over a given alphabet up to a given length.
-package main
+package main // import "rsc.io/pdf/pdfpasswd"
 
 import (
 	"flag"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in the package
to ensure that this package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
