### PR TITLE
fix a %%EOF bug

### DIFF
--- a/read.go
+++ b/read.go
@@ -128,14 +128,14 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 		return nil, fmt.Errorf("not a PDF file: invalid header")
 	}
 	end := size
-	const endChunk = 100
+	const endChunk = 1024
 	buf = make([]byte, endChunk)
 	f.ReadAt(buf, end-endChunk)
 	for len(buf) > 0 && buf[len(buf)-1] == '\n' || buf[len(buf)-1] == '\r' {
 		buf = buf[:len(buf)-1]
 	}
 	buf = bytes.TrimRight(buf, "\r\n\t ")
-	if !bytes.HasSuffix(buf, []byte("%%EOF")) {
+	if !bytes.Contains(buf, []byte("%%EOF")) {
 		return nil, fmt.Errorf("not a PDF file: missing %%%%EOF")
 	}
 	i := findLastLine(buf, "startxref")


### PR DESCRIPTION
According to ISO 32000 3.4.4 File Trailer, `%%EOF` marker appear somewhere within the last 1024 bytes of the file. 

https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/adobe_supplement_iso32000.pdf